### PR TITLE
Added example WebAC turtle files

### DIFF
--- a/src/test/resources/acls/01/acl.ttl
+++ b/src/test/resources/acls/01/acl.ttl
@@ -1,3 +1,3 @@
-@prefix ex: <http://example.com/webac#> .
+@prefix webac: <http://fedora.info/definitions/v4/webac#> .
 
-<> a ex:WebAcl .
+<> a webac:Acl .

--- a/src/test/resources/acls/01/acl.ttl
+++ b/src/test/resources/acls/01/acl.ttl
@@ -1,0 +1,3 @@
+@prefix ex: <http://example.com/webac#> .
+
+<> a ex:WebAcl .

--- a/src/test/resources/acls/01/authorization.ttl
+++ b/src/test/resources/acls/01/authorization.ttl
@@ -1,0 +1,6 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+
+<> a acl:Authorization ;
+   acl:agent "smith123" ;
+   acl:mode acl:Read, acl:Write ;
+   acl:accessTo <http://localhost:8080/rest/webacl_box1> .

--- a/src/test/resources/acls/02/acl.ttl
+++ b/src/test/resources/acls/02/acl.ttl
@@ -1,3 +1,3 @@
-@prefix ex: <http://example.com/webac#> .
+@prefix webac: <http://fedora.info/definitions/v4/webac#> .
 
-<> a ex:WebAcl .
+<> a webac:Acl .

--- a/src/test/resources/acls/02/acl.ttl
+++ b/src/test/resources/acls/02/acl.ttl
@@ -1,0 +1,3 @@
+@prefix ex: <http://example.com/webac#> .
+
+<> a ex:WebAcl .

--- a/src/test/resources/acls/02/authorization.ttl
+++ b/src/test/resources/acls/02/authorization.ttl
@@ -1,0 +1,6 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+
+<> a acl:Authorization ;
+   acl:agent "Editors" ;
+   acl:mode acl:Read, acl:Write ;
+   acl:accessTo <http://localhost:8080/rest/box/bag/collection> .

--- a/src/test/resources/acls/03/acl.ttl
+++ b/src/test/resources/acls/03/acl.ttl
@@ -1,3 +1,3 @@
-@prefix ex: <http://example.com/webac#> .
+@prefix webac: <http://fedora.info/definitions/v4/webac#> .
 
-<> a ex:WebAcl .
+<> a webac:Acl .

--- a/src/test/resources/acls/03/acl.ttl
+++ b/src/test/resources/acls/03/acl.ttl
@@ -1,0 +1,3 @@
+@prefix ex: <http://example.com/webac#> .
+
+<> a ex:WebAcl .

--- a/src/test/resources/acls/03/auth_open.ttl
+++ b/src/test/resources/acls/03/auth_open.ttl
@@ -1,0 +1,7 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<> a acl:Authorization ;
+   acl:agent foaf:Agent ;
+   acl:mode acl:Read ;
+   acl:accessTo <http://localhost:8080/rest/dark/archive/sunshine> .

--- a/src/test/resources/acls/03/auth_restricted.ttl
+++ b/src/test/resources/acls/03/auth_restricted.ttl
@@ -1,0 +1,6 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+
+<> a acl:Authorization ;
+   acl:agent "Restricted" ;
+   acl:mode acl:Read ;
+   acl:accessTo <http://localhost:8080/rest/dark/archive> .

--- a/src/test/resources/acls/04/acl.ttl
+++ b/src/test/resources/acls/04/acl.ttl
@@ -1,3 +1,3 @@
-@prefix ex: <http://example.com/webac#> .
+@prefix webac: <http://fedora.info/definitions/v4/webac#> .
 
-<> a ex:WebAcl .
+<> a webac:Acl .

--- a/src/test/resources/acls/04/acl.ttl
+++ b/src/test/resources/acls/04/acl.ttl
@@ -1,0 +1,3 @@
+@prefix ex: <http://example.com/webac#> .
+
+<> a ex:WebAcl .

--- a/src/test/resources/acls/04/auth1.ttl
+++ b/src/test/resources/acls/04/auth1.ttl
@@ -1,0 +1,7 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<> a acl:Authorization ;
+   acl:agent foaf:Agent ;
+   acl:mode acl:Read ;
+   acl:accessTo <http://localhost:8080/rest/public_collection> .

--- a/src/test/resources/acls/04/auth2.ttl
+++ b/src/test/resources/acls/04/auth2.ttl
@@ -1,0 +1,6 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+
+<> a acl:Authorization ;
+   acl:agent "Editors" ;
+   acl:mode acl:Read, acl:Write ;
+   acl:accessTo <http://localhost:8080/rest/public_collection> .

--- a/src/test/resources/acls/05/acl.ttl
+++ b/src/test/resources/acls/05/acl.ttl
@@ -1,3 +1,3 @@
-@prefix ex: <http://example.com/webac#> .
+@prefix webac: <http://fedora.info/definitions/v4/webac#> .
 
-<> a ex:WebAcl .
+<> a webac:Acl .

--- a/src/test/resources/acls/05/acl.ttl
+++ b/src/test/resources/acls/05/acl.ttl
@@ -1,0 +1,3 @@
+@prefix ex: <http://example.com/webac#> .
+
+<> a ex:WebAcl .

--- a/src/test/resources/acls/05/auth_open.ttl
+++ b/src/test/resources/acls/05/auth_open.ttl
@@ -1,0 +1,8 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix eg: <http://example.com/terms#> .
+
+<> a acl:Authorization ;
+   acl:agent foaf:Agent ;
+   acl:mode acl:Read ;
+   acl:accessToClass eg:publicImage .

--- a/src/test/resources/acls/05/auth_restricted.ttl
+++ b/src/test/resources/acls/05/auth_restricted.ttl
@@ -1,0 +1,6 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+
+<> a acl:Authorization ;
+   acl:agent 'Admins' ;
+   acl:mode acl:Read ;
+   acl:accessTo <http://localhost:8080/rest/mixedCollection> .


### PR DESCRIPTION
Taken from https://wiki.duraspace.org/display/FEDORA4x/WebAC+Authorization+Delegate

Using a dummy namespace (http://example.com/webac#) for the WebAcl class for now, this will most likely eventually be placed in a Fedora ontology.