### PR TITLE
Roles provider

### DIFF
--- a/src/main/java/org/fcrepo/auth/webac/WebACAuthorizationImpl.java
+++ b/src/main/java/org/fcrepo/auth/webac/WebACAuthorizationImpl.java
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.auth.webac.impl;
+package org.fcrepo.auth.webac;
 
 import java.net.URI;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-
-import org.fcrepo.auth.webac.WebACAuthorization;
 
 /**
  * @author acoburn

--- a/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -167,14 +167,12 @@ class WebACRolesProvider implements AccessRolesProvider {
      *  to whether the given acl:accessToClass values contain any of the rdf:type values provided
      *  when creating the predicate.
      */
-    private Function<List<String>, Predicate<WebACAuthorization>> accessToClass = uris -> {
-        return x -> {
-            return uris.stream()
-                       .distinct()
-                       .filter(y -> x.getAccessToClassURIs().contains(y))
-                       .findFirst()
-                       .isPresent();
-        };
+    private Function<List<String>, Predicate<WebACAuthorization>> accessToClass = uris -> x -> {
+        return uris.stream()
+                   .distinct()
+                   .filter(y -> x.getAccessToClassURIs().contains(y))
+                   .findFirst()
+                   .isPresent();
     };
 
     /**
@@ -203,7 +201,6 @@ class WebACRolesProvider implements AccessRolesProvider {
      *  The RDF from each child resource is put into a WebACAuthorization object, and the
      *  full list is returned.
      *
-     *  @param session the jcr session used for locating the ACL resource
      *  @param location the location of the ACL resource
      *  @return a list of acl:Authorization objects
      */

--- a/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -156,6 +156,8 @@ class WebACRolesProvider implements AccessRolesProvider {
                     });
             });
 
+        LOGGER.debug("Unfiltered ACL: {}", effectiveRoles);
+
         // Transform the effectiveRoles from a Set to a List.
         return effectiveRoles.entrySet().stream()
             .map(x -> new AbstractMap.SimpleEntry<>(x.getKey(), new ArrayList<>(x.getValue())))

--- a/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.auth.webac;
+
+import static com.hp.hpl.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.fcrepo.kernel.api.utils.UncheckedFunction.uncheck;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_NAMESPACE_VALUE;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_AUTHORIZATION;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESSTO_VALUE;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_VALUE;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESSTO_CLASS_VALUE;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_AGENT_CLASS_VALUE;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_AGENT_VALUE;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESS_CONTROL_VALUE;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.net.URI;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.fcrepo.auth.roles.common.AccessRolesProvider;
+import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.services.NodeService;
+import org.fcrepo.kernel.modeshape.rdf.impl.DefaultIdentifierTranslator;
+import org.fcrepo.kernel.modeshape.rdf.impl.PropertiesRdfContext;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.modeshape.jcr.value.Path;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.Property;
+import com.hp.hpl.jena.rdf.model.Resource;
+
+/**
+ * @author acoburn
+ * @since 9/3/15
+ */
+class WebACRolesProvider implements AccessRolesProvider {
+
+    private static final Logger LOGGER = getLogger(WebACRolesProvider.class);
+
+    private static final String FEDORA_INTERNAL_PREFIX = "info:fedora";
+
+    @Autowired
+    private NodeService nodeService;
+
+    @Override
+    public void postRoles(final Node node, final Map<String, Set<String>> data) throws RepositoryException {
+        throw new UnsupportedOperationException("postRoles() is not implemented");
+    }
+
+    @Override
+    public void deleteRoles(final Node node) throws RepositoryException {
+        throw new UnsupportedOperationException("deleteRoles() is not implemented");
+    }
+
+    @Override
+    public Map<String, List<String>> findRolesForPath(final Path absPath, final Session session)
+            throws RepositoryException {
+        LOGGER.debug("findRolesForPath: {}", absPath.getString());
+        return getAgentRoles(nodeService.find(session, absPath.getString()));
+    }
+
+    @Override
+    public Map<String, List<String>> getRoles(final Node node, final boolean effective) {
+        return getAgentRoles(nodeService.cast(node));
+    }
+
+    /**
+     *  For a given FedoraResource, get a mapping of acl:agent values to acl:mode values.
+     */
+    private Map<String, List<String>> getAgentRoles(final FedoraResource resource) {
+        LOGGER.debug("Getting agent roles for: {}", resource.getPath());
+
+        // Get the effective ACL by searching the target node and any ancestors.
+        final Optional<Pair<URI, FedoraResource>> effectiveAcl = getEffectiveAcl(resource);
+
+        // Construct a list of acceptable acl:accessTo values for the target resource.
+        final List<String> resourcePaths = new ArrayList<>();
+        resourcePaths.add(FEDORA_INTERNAL_PREFIX + resource.getPath());
+        // Construct a list of acceptable acl:accessToClass values for the target resource.
+        final List<URI> rdfTypes = resource.getTypes();
+
+        // Add the resource location and types of the ACL-bearing parent,
+        // if present and if different than the target resource.
+        effectiveAcl
+            .map(x -> x.getRight())
+            .filter(x -> !x.getPath().equals(resource.getPath()))
+            .ifPresent(x -> {
+                resourcePaths.add(FEDORA_INTERNAL_PREFIX + x.getPath());
+                rdfTypes.addAll(x.getTypes());
+            });
+
+        // Create a function to check acl:accessTo, scoped to the given resourcePaths
+        final Predicate<WebACAuthorization> checkAccessTo = accessTo.apply(resourcePaths);
+
+        // Create a function to check acl:accessToClass, scoped to the given rdf:type values;
+        // but transform the URIs to Strings first.
+        final Predicate<WebACAuthorization> checkAccessToClass =
+            accessToClass.apply(rdfTypes.stream().map(URI::toString).collect(Collectors.toList()));
+
+        // Read the effective Acl and return a list of acl:Authorization statements
+        final List<WebACAuthorization> authorizations = effectiveAcl
+                .map(uncheck(x -> getAuthorizations(resource.getNode().getSession(), x.getLeft().toString())))
+                .orElse(new ArrayList<>());
+
+        // Filter the acl:Authorization statements so that they correspond only to statements that apply to
+        // the target (or acl-bearing ancestor) resource path or rdf:type.
+        // Then, assign all acceptable acl:mode values to the relevant acl:agent values: this creates a UNION
+        // of acl:modes for each particular acl:agent.
+        final Map<String, Set<String>> effectiveRoles = new HashMap<>();
+        authorizations.stream()
+            .filter(x -> checkAccessTo.test(x) || checkAccessToClass.test(x))
+            .forEach(x -> {
+                x.getAgents().stream()
+                    .forEach(y -> {
+                        effectiveRoles.putIfAbsent(y, new HashSet<>());
+                        effectiveRoles.get(y).addAll(
+                            x.getModes().stream()
+                                        .map(URI::toString)
+                                        .collect(Collectors.toList()));
+                    });
+            });
+
+        // Transform the effectiveRoles from a Set to a List.
+        return effectiveRoles.entrySet().stream()
+            .map(x -> new AbstractMap.SimpleEntry<>(x.getKey(), new ArrayList<>(x.getValue())))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     *  This is a function for generating a Predicate that filters WebACAuthorizations according
+     *  to whether the given acl:accessToClass values contain any of the rdf:type values provided
+     *  when creating the predicate.
+     */
+    private Function<List<String>, Predicate<WebACAuthorization>> accessToClass = uris -> {
+        return x -> {
+            return uris.stream()
+                       .distinct()
+                       .filter(y -> x.getAccessToClassURIs().contains(y))
+                       .findFirst()
+                       .isPresent();
+        };
+    };
+
+    /**
+     *  This is a function for generating a Predicate that filters WebACAuthorizations according
+     *  to whether the given acl:accessTo values contain any of the target resource values provided
+     *  when creating the predicate.
+     */
+    private Function<List<String>, Predicate<WebACAuthorization>> accessTo = uris -> {
+        return x -> {
+            return uris.stream()
+                       .distinct()
+                       .filter(y -> x.getAccessToURIs().contains(y))
+                       .findFirst()
+                       .isPresent();
+        };
+    };
+
+    /**
+     *  A simple predicate for filtering out any non-acl triples.
+     */
+    final Predicate<Property> isAclPredicate =
+         p -> !p.isAnon() && p.getNameSpace().startsWith(WEBAC_NAMESPACE_VALUE);
+
+    /**
+     *  This function reads a Fedora ACL resource and all of its acl:Authorization children.
+     *  The RDF from each child resource is put into a WebACAuthorization object, and the
+     *  full list is returned.
+     *
+     *  @param session the jcr session used for locating the ACL resource
+     *  @param location the location of the ACL resource
+     *  @return a list of acl:Authorization objects
+     */
+    private List<WebACAuthorization> getAuthorizations(final Session session, final String location) {
+
+        final List<String> EMPTY = Collections.unmodifiableList(new ArrayList<>());
+        final List<WebACAuthorization> authorizations = new ArrayList<>();
+        final IdentifierConverter<Resource, FedoraResource> translator = new DefaultIdentifierTranslator(session);
+        final Model model = createDefaultModel();
+
+        LOGGER.debug("Effective ACL: {}", location);
+
+        // Find the specified ACL resource
+
+        if (location.startsWith(FEDORA_INTERNAL_PREFIX)) {
+            LOGGER.debug("ACL Path: {}", location.substring(FEDORA_INTERNAL_PREFIX.length()));
+
+            final FedoraResource resource = nodeService.find(session,
+                    location.substring(FEDORA_INTERNAL_PREFIX.length()));
+
+            // Read each child resource, filtering on acl:Authorization type, keeping only acl-prefixed triples.
+            resource.getChildren().forEachRemaining(child -> {
+                if (child.getTypes().contains(WEBAC_AUTHORIZATION)) {
+                    final Map<String, List<String>> tripleMap = new HashMap<>();
+                    child.getTriples(translator, PropertiesRdfContext.class)
+                         .filter(p -> isAclPredicate.test(model.asStatement(p).getPredicate()))
+                         .forEachRemaining(t -> {
+                            tripleMap.putIfAbsent(t.getPredicate().getURI(), new ArrayList<>());
+                             if (t.getObject().isURI()) {
+                                tripleMap.get(t.getPredicate().getURI()).add(t.getObject().getURI());
+                             } else if (t.getObject().isLiteral()) {
+                                tripleMap.get(t.getPredicate().getURI()).add(
+                                    t.getObject().getLiteralValue().toString());
+                             }
+                         });
+                    // Create a WebACAuthorization object from the provided triples.
+                    LOGGER.debug("Adding acl:Authorization from {}", child.getPath());
+                    authorizations.add(new WebACAuthorizationImpl(
+                                tripleMap.getOrDefault(WEBAC_AGENT_VALUE, EMPTY),
+                                tripleMap.getOrDefault(WEBAC_AGENT_CLASS_VALUE, EMPTY),
+                                tripleMap.getOrDefault(WEBAC_MODE_VALUE, EMPTY).stream()
+                                            .map(URI::create).collect(Collectors.toList()),
+                                tripleMap.getOrDefault(WEBAC_ACCESSTO_VALUE, EMPTY),
+                                tripleMap.getOrDefault(WEBAC_ACCESSTO_CLASS_VALUE, EMPTY)));
+                }
+            });
+        }
+        return authorizations;
+    }
+
+    /**
+     * Recursively find the effective ACL as a URI along with the FedoraResource that points to it.
+     * This way, if the effective ACL is pointed to from a parent resource, the child will inherit
+     * any permissions that correspond to access to that parent. This ACL resource may or may not exist,
+     * and it may be external to the fedora repository.
+     */
+    private static Optional<Pair<URI, FedoraResource>> getEffectiveAcl(final FedoraResource resource) {
+        try {
+            final IdentifierConverter<Resource, FedoraResource> translator =
+                new DefaultIdentifierTranslator(resource.getNode().getSession());
+            final List<String> acls = new ArrayList<>();
+            final Model model = createDefaultModel();
+
+            resource.getTriples(translator, PropertiesRdfContext.class)
+                .filter(p -> model.asStatement(p).getPredicate().hasURI(WEBAC_ACCESS_CONTROL_VALUE))
+                .forEachRemaining(t -> {
+                    if (t.getObject().isURI()) {
+                        acls.add(t.getObject().getURI());
+                    }
+                });
+            if (acls.size() > 0) {
+                if (acls.size() > 1) {
+                    LOGGER.warn("Found multiple ACLs on this node. Using: {}", acls.get(0));
+                }
+                return Optional.of(
+                        Pair.of(URI.create(acls.get(0)), resource));
+            } else if (resource.getNode().getDepth() == 0) {
+                LOGGER.debug("No ACLs defined on this node or in parent hierarchy");
+                return Optional.empty();
+            } else {
+                LOGGER.trace("Checking parent resource for ACL. No ACL found at {}", resource.getPath());
+                return getEffectiveAcl(resource.getContainer());
+            }
+        } catch (final RepositoryException ex) {
+            LOGGER.debug("Exception finding effective ACL: {}", ex);
+            return Optional.empty();
+        } catch (final Exception ex) {
+            LOGGER.debug("Some other Exception", ex);
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/test/java/org/fcrepo/auth/webac/WebACAuthorizationImplTest.java
+++ b/src/test/java/org/fcrepo/auth/webac/WebACAuthorizationImplTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.auth.webac.impl;
+package org.fcrepo.auth.webac;
 
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_READ;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_WRITE;
@@ -25,8 +25,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import org.fcrepo.auth.webac.WebACAuthorization;
 
 import org.junit.Test;
 

--- a/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
+++ b/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
@@ -45,6 +45,7 @@ import com.hp.hpl.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.fcrepo.auth.roles.common.AccessRolesProvider;
+import org.fcrepo.http.commons.session.SessionFactory;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.services.NodeService;
 import org.fcrepo.kernel.api.utils.iterators.RdfStream;
@@ -77,6 +78,9 @@ public class WebACRolesProviderTest {
     private Session mockSession;
 
     @Mock
+    private SessionFactory mockSessionFactory;
+
+    @Mock
     private NodeService mockNodeService;
 
     @Mock
@@ -102,9 +106,11 @@ public class WebACRolesProviderTest {
 
         roleProvider = new WebACRolesProvider();
         setField(roleProvider, "nodeService", mockNodeService);
+        setField(roleProvider, "sessionFactory", mockSessionFactory);
 
         when(mockNodeService.cast(mockNode)).thenReturn(mockResource);
         when(mockNode.getSession()).thenReturn(mockSession);
+        when(mockSessionFactory.getInternalSession()).thenReturn(mockSession);
 
         when(mockResource.getNode()).thenReturn(mockNode);
         when(mockNode.getDepth()).thenReturn(0);

--- a/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
+++ b/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
@@ -1,0 +1,465 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.auth.webac;
+
+import static com.hp.hpl.jena.graph.NodeFactory.createURI;
+import static com.hp.hpl.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.apache.jena.riot.Lang.TTL;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESS_CONTROL_VALUE;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_READ_VALUE;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_WRITE_VALUE;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_AUTHORIZATION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Property;
+import javax.jcr.Session;
+
+import com.hp.hpl.jena.graph.Triple;
+import com.hp.hpl.jena.rdf.model.Model;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.fcrepo.auth.roles.common.AccessRolesProvider;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.services.NodeService;
+import org.fcrepo.kernel.api.utils.iterators.RdfStream;
+import org.fcrepo.kernel.modeshape.rdf.impl.PropertiesRdfContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author acoburn
+ * @since 9/3/15
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WebACRolesProviderTest {
+
+    private AccessRolesProvider roleProvider;
+
+    private static final String FEDORA_PREFIX = "info:fedora";
+    private static final String FEDORA_URI_PREFIX = "http://localhost:8080/rest";
+
+    @Mock
+    private Node mockNode;
+
+    @Mock
+    private Node mockParentNode;
+
+    @Mock
+    private Session mockSession;
+
+    @Mock
+    private NodeService mockNodeService;
+
+    @Mock
+    private FedoraResource mockResource;
+
+    @Mock
+    private FedoraResource mockParentResource;
+
+    @Mock
+    private FedoraResource mockAclResource;
+
+    @Mock
+    private FedoraResource mockAuthorizationResource1;
+
+    @Mock
+    private FedoraResource mockAuthorizationResource2;
+
+    @Mock
+    private Property mockProperty;
+
+    @Before
+    public void setUp() throws RepositoryException {
+
+        roleProvider = new WebACRolesProvider();
+        setField(roleProvider, "nodeService", mockNodeService);
+
+        when(mockNodeService.cast(mockNode)).thenReturn(mockResource);
+        when(mockNode.getSession()).thenReturn(mockSession);
+
+        when(mockResource.getNode()).thenReturn(mockNode);
+        when(mockNode.getDepth()).thenReturn(0);
+    }
+
+    @Test
+    public void noAclTest() throws RepositoryException {
+        final String accessTo = "/dark/archive/sunshine";
+
+        when(mockResource.getPath()).thenReturn(accessTo);
+        when(mockResource.getContainer()).thenReturn(mockParentResource);
+        when(mockResource.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(new RdfStream());
+        when(mockNode.getDepth()).thenReturn(1);
+
+        when(mockParentResource.getNode()).thenReturn(mockParentNode);
+        when(mockParentResource.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(new RdfStream());
+        when(mockParentNode.getDepth()).thenReturn(0);
+
+        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+
+        assertTrue("There should be no agents in the roles map", roles.isEmpty());
+    }
+
+    @Test
+    public void acl01ParentTest() throws RepositoryException {
+        final String agent = "smith123";
+        final String accessTo = "/webacl_box1";
+        final String acl = "/acls/01";
+        final String auth = acl + "/authorization.ttl";
+
+        when(mockResource.getPath()).thenReturn(accessTo);
+        when(mockResource.getContainer()).thenReturn(mockParentResource);
+        when(mockResource.getPath()).thenReturn(accessTo + "/foo");
+        when(mockResource.getTriples(anyObject(), eq(PropertiesRdfContext.class)))
+                .thenReturn(new RdfStream());
+        when(mockNode.getDepth()).thenReturn(1);
+
+        when(mockParentResource.getNode()).thenReturn(mockParentNode);
+        when(mockParentResource.getPath()).thenReturn(accessTo);
+        when(mockParentResource.getTriples(anyObject(), eq(PropertiesRdfContext.class)))
+                .thenReturn(getResourceRdfStream(accessTo, acl));
+        when(mockParentNode.getDepth()).thenReturn(0);
+
+        when(mockProperty.getString()).thenReturn(acl);
+        when(mockNodeService.find(mockSession, acl)).thenReturn(mockAclResource);
+        when(mockAclResource.getPath()).thenReturn(acl);
+
+        when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource1.getPath()).thenReturn(auth);
+        when(mockAuthorizationResource1.getTriples(anyObject(), eq(PropertiesRdfContext.class)))
+                .thenReturn(getRdfStreamFromResource(auth, TTL));
+
+        when(mockAclResource.getChildren()).thenReturn(Arrays.asList(mockAuthorizationResource1).iterator());
+
+        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+
+        assertEquals("There should be exactly one agent in the role map", 1, roles.size());
+        assertEquals("The agent should have exactly two modes", 2, roles.get(agent).size());
+        assertTrue("The agent should be able to read", roles.get(agent).contains(WEBAC_MODE_READ_VALUE));
+        assertTrue("The agent should be able to write", roles.get(agent).contains(WEBAC_MODE_WRITE_VALUE));
+    }
+
+    @Test
+    public void acl01Test1() throws RepositoryException {
+        final String agent = "smith123";
+        final String accessTo = "/webacl_box1";
+        final String acl = "/acls/01";
+        final String auth = acl + "/authorization.ttl";
+
+        when(mockNodeService.find(mockSession, acl)).thenReturn(mockAclResource);
+        when(mockProperty.getString()).thenReturn(acl);
+        when(mockAclResource.getPath()).thenReturn(acl);
+        when(mockResource.getPath()).thenReturn(accessTo);
+        when(mockResource.getTriples(anyObject(), eq(PropertiesRdfContext.class)))
+                .thenReturn(getResourceRdfStream(accessTo, acl));
+
+        when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource1.getPath()).thenReturn(auth);
+        when(mockAuthorizationResource1.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(getRdfStreamFromResource(auth, TTL));
+
+        when(mockAclResource.getChildren()).thenReturn(Arrays.asList(mockAuthorizationResource1).iterator());
+
+        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+
+        assertEquals("There should be exactly one agent in the role map", 1, roles.size());
+        assertEquals("The agent should have exactly two modes", 2, roles.get(agent).size());
+        assertTrue("The agent should be able to read", roles.get(agent).contains(WEBAC_MODE_READ_VALUE));
+        assertTrue("The agent should be able to write", roles.get(agent).contains(WEBAC_MODE_WRITE_VALUE));
+    }
+
+    @Test
+    public void acl01Test2() throws RepositoryException {
+        final String accessTo = "/webacl_box2";
+        final String acl = "/acls/01";
+        final String auth = acl + "/authorization.ttl";
+
+        when(mockNodeService.find(mockSession, acl)).thenReturn(mockAclResource);
+        when(mockProperty.getString()).thenReturn(acl);
+        when(mockAclResource.getPath()).thenReturn(acl);
+        when(mockResource.getPath()).thenReturn(accessTo);
+        when(mockResource.getTriples(anyObject(), eq(PropertiesRdfContext.class)))
+                .thenReturn(getResourceRdfStream(accessTo, acl));
+
+        when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource1.getPath()).thenReturn(auth);
+        when(mockAuthorizationResource1.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(getRdfStreamFromResource(auth, TTL));
+
+        when(mockAclResource.getChildren()).thenReturn(Arrays.asList(mockAuthorizationResource1).iterator());
+
+        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+
+        assertTrue("There should be no agents associated with this object", roles.isEmpty());
+    }
+
+    @Test
+    public void acl02Test() throws RepositoryException {
+        final String agent = "Editors";
+        final String accessTo = "/box/bag/collection";
+        final String acl = "/acls/02";
+        final String auth = acl + "/authorization.ttl";
+
+        when(mockNodeService.find(mockSession, acl)).thenReturn(mockAclResource);
+        when(mockProperty.getString()).thenReturn(acl);
+        when(mockAclResource.getPath()).thenReturn(acl);
+        when(mockResource.getPath()).thenReturn(accessTo);
+        when(mockResource.getTriples(anyObject(), eq(PropertiesRdfContext.class)))
+                .thenReturn(getResourceRdfStream(accessTo, acl));
+
+        when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource1.getPath()).thenReturn(auth);
+        when(mockAuthorizationResource1.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(getRdfStreamFromResource(auth, TTL));
+
+        when(mockAclResource.getChildren()).thenReturn(Arrays.asList(mockAuthorizationResource1).iterator());
+
+        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+
+        assertEquals("There should be exactly one agent in the role map", 1, roles.size());
+        assertEquals("The agent should have exactly two modes", 2, roles.get(agent).size());
+        assertTrue("The agent should be able to read", roles.get(agent).contains(WEBAC_MODE_READ_VALUE));
+        assertTrue("The agent should be able to write", roles.get(agent).contains(WEBAC_MODE_WRITE_VALUE));
+    }
+
+    @Test
+    public void acl03Test1() throws RepositoryException {
+        final String agent = "http://xmlns.com/foaf/0.1/Agent";
+        final String accessTo = "/dark/archive/sunshine";
+        final String acl = "/acls/03";
+        final String auth1 = acl + "/auth_restricted.ttl";
+        final String auth2 = acl + "/auth_open.ttl";
+
+        when(mockNodeService.find(mockSession, acl)).thenReturn(mockAclResource);
+        when(mockProperty.getString()).thenReturn(acl);
+        when(mockAclResource.getPath()).thenReturn(acl);
+        when(mockResource.getPath()).thenReturn(accessTo);
+        when(mockResource.getTriples(anyObject(), eq(PropertiesRdfContext.class)))
+                .thenReturn(getResourceRdfStream(accessTo, acl));
+
+        when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource1.getPath()).thenReturn(auth1);
+        when(mockAuthorizationResource1.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(getRdfStreamFromResource(auth1, TTL));
+
+        when(mockAuthorizationResource2.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource2.getPath()).thenReturn(auth2);
+        when(mockAuthorizationResource2.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(getRdfStreamFromResource(auth2, TTL));
+
+        when(mockAclResource.getChildren()).thenReturn(
+                Arrays.asList(mockAuthorizationResource1, mockAuthorizationResource2).iterator());
+
+        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+
+        assertEquals("There should be exactly one agent in the roles map", 1, roles.size());
+        assertEquals("The agent should have exactly one mode", 1, roles.get(agent).size());
+        assertTrue("The agent should be able to read", roles.get(agent).contains(WEBAC_MODE_READ_VALUE));
+    }
+
+    @Test
+    public void acl03Test2() throws RepositoryException {
+        final String agent = "Restricted";
+        final String accessTo = "/dark/archive";
+        final String acl = "/acls/03";
+        final String auth1 = acl + "/auth_restricted.ttl";
+        final String auth2 = acl + "/auth_open.ttl";
+
+        when(mockNodeService.find(mockSession, acl)).thenReturn(mockAclResource);
+        when(mockProperty.getString()).thenReturn(acl);
+        when(mockAclResource.getPath()).thenReturn(acl);
+        when(mockResource.getPath()).thenReturn(accessTo);
+        when(mockResource.getTriples(anyObject(), eq(PropertiesRdfContext.class)))
+                .thenReturn(getResourceRdfStream(accessTo, acl));
+
+        when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource1.getPath()).thenReturn(auth1);
+        when(mockAuthorizationResource1.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(getRdfStreamFromResource(auth1, TTL));
+
+        when(mockAuthorizationResource2.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource2.getPath()).thenReturn(auth2);
+        when(mockAuthorizationResource2.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(getRdfStreamFromResource(auth2, TTL));
+
+        when(mockAclResource.getChildren()).thenReturn(
+                Arrays.asList(mockAuthorizationResource1, mockAuthorizationResource2).iterator());
+
+        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+
+        assertEquals("There should be exactly one agent", 1, roles.size());
+        assertEquals("The agent should have one mode", 1, roles.get(agent).size());
+        assertTrue("The agent should be able to read", roles.get(agent).contains(WEBAC_MODE_READ_VALUE));
+    }
+
+    @Test
+    public void acl04Test() throws RepositoryException {
+        final String agent1 = "http://xmlns.com/foaf/0.1/Agent";
+        final String agent2 = "Editors";
+        final String accessTo = "/public_collection";
+        final String acl = "/acls/04";
+        final String auth1 = acl + "/auth1.ttl";
+        final String auth2 = acl + "/auth2.ttl";
+
+        when(mockNodeService.find(mockSession, acl)).thenReturn(mockAclResource);
+        when(mockProperty.getString()).thenReturn(acl);
+        when(mockAclResource.getPath()).thenReturn(acl);
+        when(mockResource.getPath()).thenReturn(accessTo);
+        when(mockResource.getTriples(anyObject(), eq(PropertiesRdfContext.class)))
+                .thenReturn(getResourceRdfStream(accessTo, acl));
+
+        when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource1.getPath()).thenReturn(auth1);
+        when(mockAuthorizationResource1.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(getRdfStreamFromResource(auth1, TTL));
+
+        when(mockAuthorizationResource2.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource2.getPath()).thenReturn(auth2);
+        when(mockAuthorizationResource2.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(getRdfStreamFromResource(auth2, TTL));
+
+        when(mockAclResource.getChildren()).thenReturn(
+                Arrays.asList(mockAuthorizationResource1, mockAuthorizationResource2).iterator());
+
+        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+
+        assertEquals("There should be exactly two agents", 2, roles.size());
+        assertEquals("The agent should have one mode", 1, roles.get(agent1).size());
+        assertTrue("The agent should be able to read", roles.get(agent1).contains(WEBAC_MODE_READ_VALUE));
+        assertEquals("The agent should have two modes", 2, roles.get(agent2).size());
+        assertTrue("The agent should be able to read", roles.get(agent2).contains(WEBAC_MODE_READ_VALUE));
+        assertTrue("The agent should be able to write", roles.get(agent2).contains(WEBAC_MODE_READ_VALUE));
+    }
+
+    public void acl05Test() throws RepositoryException {
+        final String agent1 = "http://xmlns.com/foaf/0.1/Agent";
+        final String agent2 = "Admins";
+        final String accessTo = "/mixedCollection";
+        final String acl = "/acls/05";
+        final String auth1 = acl + "/auth_restricted.ttl";
+        final String auth2 = acl + "/auth_open.ttl";
+
+        when(mockNodeService.find(mockSession, acl)).thenReturn(mockAclResource);
+        when(mockProperty.getString()).thenReturn(acl);
+        when(mockAclResource.getPath()).thenReturn(acl);
+        when(mockResource.getPath()).thenReturn(accessTo);
+        when(mockResource.getTypes()).thenReturn(Arrays.asList(URI.create("http://example.com/terms#publicImage")));
+        when(mockResource.getTriples(anyObject(), eq(PropertiesRdfContext.class)))
+                .thenReturn(getResourceRdfStream(accessTo, acl));
+
+        when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource1.getPath()).thenReturn(auth1);
+        when(mockAuthorizationResource1.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(getRdfStreamFromResource(auth1, TTL));
+
+        when(mockAuthorizationResource2.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource2.getPath()).thenReturn(auth2);
+        when(mockAuthorizationResource2.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(getRdfStreamFromResource(auth2, TTL));
+
+        when(mockAclResource.getChildren()).thenReturn(
+                Arrays.asList(mockAuthorizationResource1, mockAuthorizationResource2).iterator());
+
+        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+
+        assertEquals("There should be exactly two agents", 2, roles.size());
+        assertEquals("The agent should have one mode", 1, roles.get(agent1).size());
+        assertTrue("The agent should be able to read", roles.get(agent1).contains(WEBAC_MODE_READ_VALUE));
+        assertEquals("The agent should have one mode", 1, roles.get(agent2).size());
+        assertTrue("The agent should be able to read", roles.get(agent2).contains(WEBAC_MODE_READ_VALUE));
+    }
+
+    @Test
+    public void acl05Test2() throws RepositoryException {
+        final String agent1 = "http://xmlns.com/foaf/0.1/Agent";
+        final String accessTo = "/someOtherCollection";
+        final String acl = "/acls/05";
+        final String auth1 = acl + "/auth_restricted.ttl";
+        final String auth2 = acl + "/auth_open.ttl";
+
+        when(mockNodeService.find(mockSession, acl)).thenReturn(mockAclResource);
+        when(mockProperty.getString()).thenReturn(acl);
+        when(mockAclResource.getPath()).thenReturn(acl);
+        when(mockResource.getPath()).thenReturn(accessTo);
+        when(mockResource.getTypes()).thenReturn(Arrays.asList(URI.create("http://example.com/terms#publicImage")));
+        when(mockResource.getTriples(anyObject(), eq(PropertiesRdfContext.class)))
+                .thenReturn(getResourceRdfStream(accessTo, acl));
+
+        when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource1.getPath()).thenReturn(auth1);
+        when(mockAuthorizationResource1.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(getRdfStreamFromResource(auth1, TTL));
+
+        when(mockAuthorizationResource2.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource2.getPath()).thenReturn(auth2);
+        when(mockAuthorizationResource2.getTriples(anyObject(),
+                    eq(PropertiesRdfContext.class))).thenReturn(getRdfStreamFromResource(auth2, TTL));
+
+        when(mockAclResource.getChildren()).thenReturn(
+                Arrays.asList(mockAuthorizationResource1, mockAuthorizationResource2).iterator());
+
+        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+
+        assertEquals("There should be exactly agent", 1, roles.size());
+        assertEquals("The agent should have one mode", 1, roles.get(agent1).size());
+        assertTrue("The agent should be able to read", roles.get(agent1).contains(WEBAC_MODE_READ_VALUE));
+    }
+
+
+    private static RdfStream getRdfStreamFromResource(final String resourcePath, final Lang lang) {
+        final Model model = createDefaultModel();
+
+        RDFDataMgr.read(model, WebACRolesProviderTest.class.getResourceAsStream(resourcePath), lang);
+
+        final List<Triple> triples = new ArrayList<>();
+        model.listStatements().forEachRemaining(x -> {
+            final Triple t = x.asTriple();
+            if (t.getObject().isURI() && t.getObject().getURI().startsWith(FEDORA_URI_PREFIX)) {
+                triples.add(new Triple(t.getSubject(), t.getPredicate(),
+                        createURI(FEDORA_PREFIX + t.getObject().getURI().substring(FEDORA_URI_PREFIX.length()))));
+            } else {
+                triples.add(t);
+            }
+        });
+
+        return new RdfStream(triples);
+    }
+
+    private RdfStream getResourceRdfStream(final String subject, final String aclTarget) {
+        return new RdfStream(Arrays.asList(
+                    new Triple(createURI(FEDORA_PREFIX + subject),
+                               createURI(WEBAC_ACCESS_CONTROL_VALUE),
+                               createURI(FEDORA_PREFIX + aclTarget))
+                ));
+    }
+}

--- a/src/test/resources/spring-test/repo.xml
+++ b/src/test/resources/spring-test/repo.xml
@@ -19,6 +19,8 @@
 
   <bean name="fad" class="org.fcrepo.auth.webac.WebACAuthorizationDelegate"/>
 
+  <bean name="accessRolesProvider" class="org.fcrepo.auth.webac.WebACRolesProvider"/>
+
   <bean class="org.modeshape.jcr.ModeShapeEngine" init-method="start"/>
 
   <bean id="connectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager"/>


### PR DESCRIPTION
Implement an AccessRolesProvider class.

This class is one of the missing links in our implementation. With it in place (and with the corresponding Spring configuration as shown in this PR), ACL resources are read, processed and user roles are added into the FAD.

This implementation has a complete unit testing framework, but it is a bit rough around the edges in two respects:

  * I have hard-coded the `info:fedora` prefix into the class (it's not defined in the fedora kernel api). This is needed b/c triples pointing to repository resources use that prefix. Should that value be added to the kernel-api? Or should I be using a different translator when reading the Triples (I am currently using `DefaultIdentifierTranslator`)?
  * I moved the `WebACAuthorizationImpl` class out of the impl package. OSGi won't export those packages, and I thought that would be fine, since those aren't public-facing, but when deploying this with the class in `.impl`, I get `ClassNotFoundException`s. Moving it into the `.webac` package fixes that. In this case, I'm somewhat inclined to turn `WebACAuthorization` into a fully-fledged class, rather than keeping it as an interface with a separate implementation.